### PR TITLE
Add missing quotation mark in code sample in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use it like so:
 var cli struct {
     Config kong.ConfigFlag `help:"Load configuration."`
 }
-parser, err := kong.New(&cli, kong.Configuration(konghcl.Loader, "/etc/myapp/config.hcl", "~/.myapp.hcl))
+parser, err := kong.New(&cli, kong.Configuration(konghcl.Loader, "/etc/myapp/config.hcl", "~/.myapp.hcl"))
 ```
 
 ## Mapping HCL fragments to a struct


### PR DESCRIPTION
I was trying to see how much gofmt would indent the code, using the Go Playground, if I were to split the long `parser, err :=` line in two to fit 80-column width for Debian package description, but then noticed the code wouldn't run, and eventually spotted the missing close quotation mark.