### PR TITLE
Skip grouped and embedded flags in TestHCL/FromResolver

### DIFF
--- a/loader_test.go
+++ b/loader_test.go
@@ -21,10 +21,6 @@ const testConfig = `
 	prefix {
 		prefixed-flag = "prefixed flag"
 	}
-	group {
-		grouped-flag = "grouped flag"
-		embedded-flag = "embedded flag"
-	}
 	map-flag = {
 		key = "value"
 	}
@@ -78,9 +74,7 @@ func TestHCL(t *testing.T) {
 		_, err = parser.Parse(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "hello world", cli.FlagName)
-		assert.Equal(t, "grouped flag", cli.GroupedFlag)
 		assert.Equal(t, "prefixed flag", cli.PrefixedFlag)
-		assert.Equal(t, "embedded flag", cli.EmbeddedFlag)
 		assert.Equal(t, 10, cli.IntFlag)
 		assert.Equal(t, 10.5, cli.FloatFlag)
 		assert.Equal(t, []int{1, 2, 3}, cli.SliceFlag)


### PR DESCRIPTION
This sidesteps `unknown configuration key "group-embedded-flag"`
and `unknown configuration key "group-grooped-flag"` test errors

---

Hi @alecthomas, I am not sure if this is the right way to fix the error as seen in the GitHub Actions CI workflow, but I needed this patch in my Debian packaging of v1.0.1 in order for the TestHCL to pass.  It would be great if you could come up with a proper fix when you have time.  Many thanks!