### PR TITLE
Add HCLFileMapper

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -1,0 +1,39 @@
+package konghcl
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+
+	"github.com/alecthomas/kong"
+	"github.com/hashicorp/hcl"
+)
+
+// HCLFileMapper implements kong.MapperValue to decode an HCL file into
+// a struct field.
+//
+//    var cli struct {
+//      Profile Profile `type:"hclfile"`
+//    }
+//
+//    func main() {
+//      kong.Parse(&cli, kong.NamedMapper("hclfile", konghcl.HCLFileMapper))
+//    }
+var HCLFileMapper = kong.MapperFunc(decodeHCLFile) //hsnolint: gochecknoglobals
+
+func decodeHCLFile(ctx *kong.DecodeContext, target reflect.Value) error {
+	var fname string
+	if err := ctx.Scan.PopValueInto("filename", &fname); err != nil {
+		return err
+	}
+	f, err := os.Open(fname) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	return hcl.Unmarshal(b, target.Addr().Interface())
+}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -1,0 +1,47 @@
+package konghcl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+)
+
+type TestSample struct {
+	Name string `hcl:"name"`
+	Game string `hcl:"game"`
+}
+
+func TestHCLFileMapper(t *testing.T) {
+	var cli struct {
+		Sample TestSample `type:"hclfile"`
+	}
+	opt := kong.NamedMapper("hclfile", HCLFileMapper)
+	parser, err := kong.New(&cli, opt)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"--sample", "testdata/sample.hcl"})
+	require.NoError(t, err)
+
+	want := TestSample{Name: "Lee Sedol", Game: "Go"}
+	require.Equal(t, want, cli.Sample)
+}
+
+func TestHCLFileMapperErr(t *testing.T) {
+	var cli struct {
+		Sample TestSample `type:"hclfile"`
+	}
+	opts := []kong.Option{
+		kong.NamedMapper("hclfile", HCLFileMapper),
+		kong.Exit(func(int) { fmt.Println("EXIT") }),
+	}
+	parser, err := kong.New(&cli, opts...)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"--sample", "testdata/MISSING_FILE.hcl"})
+	require.Error(t, err)
+
+	_, err = parser.Parse([]string{"--sample"})
+	require.Error(t, err)
+}

--- a/testdata/sample.hcl
+++ b/testdata/sample.hcl
@@ -1,0 +1,2 @@
+name= "Lee Sedol"
+game= "Go"


### PR DESCRIPTION
HCLFileMapper implements kong.MapperValue to decode an HCL file into
a struct field. Sample usage:

        var cli struct {
          Profile Profile `type:"hclfile"`
        }

        func main() {
          kong.Parse(&cli, kong.NamedMapper("hclfile", konghcl.HCLFileMapper))
        }